### PR TITLE
解决 newtx 1.60 版本后与 ctex 冲突的问题

### DIFF
--- a/tongjithesis.cls
+++ b/tongjithesis.cls
@@ -106,6 +106,11 @@
 % 为 CMR。其他引擎下没有这个问题，这一行会被无视。
 \PassOptionsToPackage{no-math}{fontspec}
 
+% , 设置 Times New Roman，Helvetic.
+% 这是txfonts的替代品，即txfonts.sty分成了俩独立的package：newtxtext 和 newtxmath
+\RequirePackage[defaultsups]{newtxtext}
+\RequirePackage{newtxmath}
+
 %将伪粗体与伪斜体的选项传递给xeCJK package
 \PassOptionsToPackage{AutoFakeBold=1.2,AutoFakeSlant}{xeCJK}
 % 使用 \CTeX\ 宏宝的默认中文字体配置，支持不同引擎
@@ -126,11 +131,6 @@
 
 % \AmSTeX\ 宏包，用来排出更加漂亮的公式。
 \RequirePackage{amsmath,amssymb}
-
-% , 设置 Times New Roman，Helvetic.
-% 这是txfonts的替代品，即txfonts.sty分成了俩独立的package：newtxtext 和 newtxmath
-\RequirePackage[defaultsups]{newtxtext}
-\RequirePackage{newtxmath}
 
 % 使用 Courier 字体
 \RequirePackage{courier}


### PR DESCRIPTION
## 问题描述

编译报错

```
LaTeX Err
or: Command `\lvert' already defined.
LaTeX Err
or: Command `\rvert' already defined.
LaTeX Err
or: Command `\lVert' already defined.
LaTeX Err
or: Command `\rVert' already defined.
```

## 编译环境

- 系统：Debian

- TeX 发行版：TeX Live 2019

## 相关讨论
- [CTeX-org/ctex-kit #454](https://github.com/CTeX-org/ctex-kit/issues/454)

- [sjtug/SJTUThesis #457](https://github.com/sjtug/SJTUThesis/issues/457)

- [ElegantLaTeX/ElegantBook #59](https://github.com/ElegantLaTeX/ElegantBook/issues/59)

此问题应该只影响 TeX Live 2019 且 newtx 1.60 版本以后。
